### PR TITLE
Prevent subscription after user disconnect

### DIFF
--- a/src/redis-subscriber.ts
+++ b/src/redis-subscriber.ts
@@ -49,6 +49,10 @@ export default class RedisSubscriber {
   }
 
   subscribe(channels: string | string[], connection: UserConnection) {
+    if (!connection.isActive()) {
+      return;
+    }
+
     if (!Array.isArray(channels)) {
       channels = [channels];
     }

--- a/src/redis-subscriber.ts
+++ b/src/redis-subscriber.ts
@@ -49,7 +49,7 @@ export default class RedisSubscriber {
   }
 
   subscribe(channels: string | string[], connection: UserConnection) {
-    if (!connection.isActive()) {
+    if (!connection.isActive) {
       return;
     }
 

--- a/src/user-connection.ts
+++ b/src/user-connection.ts
@@ -38,6 +38,10 @@ export default class UserConnection {
   private pingTimeout?: NodeJS.Timeout;
   private session: UserSession;
 
+  get isActive() {
+    return this.active;
+  }
+
   constructor(session: UserSession, config: UserConnectionConfig) {
     this.config = config;
     this.session = session;
@@ -85,10 +89,6 @@ export default class UserConnection {
           this.config.ws.send(messageString, ignoreError);
         }
     }
-  }
-
-  isActive = () => {
-    return this.active;
   }
 
   sessionCheck = (message: any) => {

--- a/src/user-connection.ts
+++ b/src/user-connection.ts
@@ -87,6 +87,10 @@ export default class UserConnection {
     }
   }
 
+  isActive = () => {
+    return this.active;
+  }
+
   sessionCheck = (message: any) => {
     if (message.event === 'logout') {
       for (const key of message.data.keys) {
@@ -102,11 +106,6 @@ export default class UserConnection {
 
   subscribe = async () => {
     const subscriptions = await this.subscriptions();
-
-    // may be closed during await above
-    if (!this.active) {
-      return;
-    }
 
     this.config.redisSubscriber.subscribe(subscriptions, this);
   }


### PR DESCRIPTION
Thanks to async, user connection may go like this:

0. [a] boot
1. [b] fetch subscription list
2. [a] disconnect
3. [a] unsubscribe
4. [b] fetch done, subscribe &larr; whoops
5. memory leak