### PR TITLE
Always cleanup on close() call

### DIFF
--- a/src/user-connection.ts
+++ b/src/user-connection.ts
@@ -64,11 +64,9 @@ export default class UserConnection {
   }
 
   close = () => {
-    if (!this.active) {
-      return;
+    if (this.active) {
+      logger.debug(`user ${this.session.userId} (${this.session.ip}) disconnected`);
     }
-
-    logger.debug(`user ${this.session.userId} (${this.session.ip}) disconnected`);
 
     this.active = false;
     this.ws.terminate();


### PR DESCRIPTION
Just in case ┐(' ヮ' )┌