### PR TITLE
Handle user verification event

### DIFF
--- a/src/laravel-session.ts
+++ b/src/laravel-session.ts
@@ -38,7 +38,9 @@ interface EncryptedSession {
 interface Session {
   csrf: string;
   key: string;
+  requiresVerification: boolean;
   userId: number;
+  verified: boolean;
 }
 
 const isEncryptedSession = (arg: any): arg is EncryptedSession => {
@@ -79,11 +81,15 @@ export default class LaravelSession {
 
     const rawData = unserialize(unserialize(serializedData), {}, {strict: false});
 
+    // login_<authName>_<hashedAuthClass>
+    const userId = rawData.login_web_59ba36addc2b2f9401580f014c7f58ea4e30989d;
+
     return {
       csrf: rawData._token,
       key,
-      // login_<authName>_<hashedAuthClass>
-      userId: rawData.login_web_59ba36addc2b2f9401580f014c7f58ea4e30989d,
+      requiresVerification: rawData.requires_verification,
+      userId,
+      verified: rawData.verified,
     };
   }
 
@@ -141,7 +147,9 @@ export default class LaravelSession {
     if (hasValidToken) {
       return {
         key: session.key,
+        requiresVerification: session.requiresVerification,
         userId: session.userId,
+        verified: session.verified,
       };
     } else {
       throw new Error('invalid csrf token');

--- a/src/oauth-verifier.ts
+++ b/src/oauth-verifier.ts
@@ -109,7 +109,9 @@ export default class OAuthVerifier {
       if (scope === '*' || scope === 'read') {
         return {
           key: `oauth:${oAuthToken}`,
+          requiresVerification: false,
           userId,
+          verified: false,
         };
       }
     }

--- a/src/types/user-session.ts
+++ b/src/types/user-session.ts
@@ -19,5 +19,7 @@
 export default interface UserSession {
   ip?: string;
   key: string;
+  requiresVerification: boolean;
   userId: number;
+  verified: boolean;
 }

--- a/src/user-connection.ts
+++ b/src/user-connection.ts
@@ -84,6 +84,10 @@ export default class UserConnection {
         this.sessionCheck(message);
         break;
       default:
+        if (this.session.requiresVerification && !this.session.verified) {
+          return;
+        }
+
         logger.debug(`sending event ${message.event} to ${this.session.userId} (${this.session.ip})`);
         if (typeof message.data === 'object' && message.data.source_user_id !== this.session.userId) {
           this.ws.send(messageString, noop);
@@ -120,6 +124,7 @@ export default class UserConnection {
         break;
       case 'verified':
         if (message.data.key === this.session.key) {
+          this.session.verified = true;
           this.ws.send(JSON.stringify({ event: 'verified' }), noop);
         }
     }

--- a/src/user-connection.ts
+++ b/src/user-connection.ts
@@ -107,15 +107,21 @@ export default class UserConnection {
   }
 
   sessionCheck = (message: any) => {
-    if (message.event === 'logout') {
-      for (const key of message.data.keys) {
-        if (key === this.session.key) {
-          this.ws.send(JSON.stringify({ event: 'logout' }), () => {
-            logger.debug(`user ${this.session.userId} (${this.session.ip}) logged out`);
-            this.ws.close();
-          });
+    switch (message.event) {
+      case 'logout':
+        for (const key of message.data.keys) {
+          if (key === this.session.key) {
+            this.ws.send(JSON.stringify({ event: 'logout' }), () => {
+              logger.debug(`user ${this.session.userId} (${this.session.ip}) logged out`);
+              this.ws.close();
+            });
+          }
         }
-      }
+        break;
+      case 'verified':
+        if (message.data.key === this.session.key) {
+          this.ws.send(JSON.stringify({ event: 'verified' }), noop);
+        }
     }
   }
 

--- a/src/user-connection.ts
+++ b/src/user-connection.ts
@@ -122,6 +122,11 @@ export default class UserConnection {
           }
         }
         break;
+      case 'verification_requirement_change':
+        if (message.data.key === this.session.key) {
+          this.session.requiresVerification = message.data.requires_verification;
+        }
+        break;
       case 'verified':
         if (message.data.key === this.session.key) {
           this.session.verified = true;

--- a/src/user-connection.ts
+++ b/src/user-connection.ts
@@ -123,9 +123,7 @@ export default class UserConnection {
         }
         break;
       case 'verification_requirement_change':
-        if (message.data.key === this.session.key) {
-          this.session.requiresVerification = message.data.requires_verification;
-        }
+        this.session.requiresVerification = message.data.requires_verification;
         break;
       case 'verified':
         if (message.data.key === this.session.key) {


### PR DESCRIPTION
Take 2 because #22 is kinda broken.

Don't send messages on users which require verification but not verified. As the field doesn't exist in session at the moment it shouldn't do anything.