### PR TITLE
Add private channel subscription

### DIFF
--- a/src/user-connection.ts
+++ b/src/user-connection.ts
@@ -155,6 +155,7 @@ export default class UserConnection {
     ret.push(`notification_read:${this.session.userId}`);
     ret.push(this.subscriptionUpdateChannel());
     ret.push(this.userSessionChannel());
+    ret.push(`private:user:${this.session.userId}`);
 
     return ret;
   }


### PR DESCRIPTION
Subscribes to a user-specific channel used to publish notifications to specific lists of users; although, we should probably combine the user-specific notifications into a single channel?

used for ppy/osu-web#5101