### PR TITLE
Allow receiving notifications even if source and destination users are the same

### DIFF
--- a/src/user-connection.ts
+++ b/src/user-connection.ts
@@ -82,7 +82,7 @@ export default class UserConnection {
         }
 
         logger.debug(`sending event ${message.event} to ${this.session.userId} (${this.session.ip})`);
-        if (typeof message.data !== 'object' || message.data.source_user_id === this.session.userId) {
+        if (typeof message.data !== 'object') {
           return;
         }
 


### PR DESCRIPTION
There's no need to check for this now since notifications channels are now per-user and you'd want to receive notifications triggered by yourself where appropriate, anyway.