### PR TITLE
Add support for filtering out disconnected chat clients

### DIFF
--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -14,7 +14,7 @@ interface LogoutMessage extends MessageBase {
   event: 'logout';
 }
 
-interface VerificationRequirementChangeMessage extends MessageBase  {
+interface VerificationRequirementChangeMessage extends MessageBase {
   data: { requires_verification: boolean };
   event: 'verification_requirement_change';
 }

--- a/src/types/socket-message.ts
+++ b/src/types/socket-message.ts
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+export function isSocketMessage(arg: unknown): arg is SocketMessage {
+  return typeof arg === 'object'
+    && arg != null
+    && 'event' in arg;
+}
+
+interface SocketMessage {
+  data?: unknown;
+  event: string;
+}

--- a/src/types/socket-message.ts
+++ b/src/types/socket-message.ts
@@ -1,13 +1,31 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-export function isSocketMessage(arg: unknown): arg is SocketMessage {
+import * as WebSocket from 'ws';
+import logger from '../logger';
+
+function isSocketMessage(arg: unknown): arg is SocketMessage {
   return typeof arg === 'object'
     && arg != null
-    && 'event' in arg;
+    && 'event' in arg
+    && typeof (arg as SocketMessage).event === 'string';
+}
+
+export function parseSocketMessage(data: WebSocket.Data) {
+  if (typeof data !== 'string') return null;
+
+  try {
+    const json = JSON.parse(data) as unknown;
+    if (isSocketMessage(json)) {
+      return json;
+    }
+  } catch (error) {
+    logger.debug(error);
+  }
+
+  return null;
 }
 
 interface SocketMessage {
-  data?: unknown;
   event: string;
 }

--- a/src/user-connection.ts
+++ b/src/user-connection.ts
@@ -7,6 +7,7 @@ import logger from './logger';
 import noop from './noop';
 import RedisSubscriber from './redis-subscriber';
 import Message from './types/message';
+import { isSocketMessage } from './types/socket-message';
 import UserSession from './types/user-session';
 
 interface Params {
@@ -87,13 +88,15 @@ export default class UserConnection {
     if (typeof data !== 'string') return;
 
     try {
-      const json = JSON.parse(data);
+      const json = JSON.parse(data) as unknown;
       if (json == null) return;
 
-      if (json.event === 'chat.start') {
-        this.chatActive = true;
-      } else if (json.event === 'chat.end') {
-        this.chatActive = false;
+      if (isSocketMessage(json)) {
+        if (json.event === 'chat.start') {
+          this.chatActive = true;
+        } else if (json.event === 'chat.end') {
+          this.chatActive = false;
+        }
       }
     } catch (error) {
       logger.debug(error);

--- a/src/user-connection.ts
+++ b/src/user-connection.ts
@@ -7,7 +7,7 @@ import logger from './logger';
 import noop from './noop';
 import RedisSubscriber from './redis-subscriber';
 import Message from './types/message';
-import { isSocketMessage } from './types/socket-message';
+import { parseSocketMessage } from './types/socket-message';
 import UserSession from './types/user-session';
 
 interface Params {
@@ -85,21 +85,13 @@ export default class UserConnection {
   };
 
   handleMessage = (data: WebSocket.Data) => {
-    if (typeof data !== 'string') return;
+    const messsage = parseSocketMessage(data);
+    if (messsage == null) return;
 
-    try {
-      const json = JSON.parse(data) as unknown;
-      if (json == null) return;
-
-      if (isSocketMessage(json)) {
-        if (json.event === 'chat.start') {
-          this.chatActive = true;
-        } else if (json.event === 'chat.end') {
-          this.chatActive = false;
-        }
-      }
-    } catch (error) {
-      logger.debug(error);
+    if (messsage.event === 'chat.start') {
+      this.chatActive = true;
+    } else if (messsage.event === 'chat.end') {
+      this.chatActive = false;
     }
   };
 


### PR DESCRIPTION
Just basic support where the client tells whether they're on chat or not.

Future improvements would be having it update the Redis keys used for filtering out the Laravel-side broadcast since the web socket server is a better indicator of knowing which clients are still connected.