### PR TITLE
Mark oauth connection as verified

### DIFF
--- a/src/oauth-verifier.ts
+++ b/src/oauth-verifier.ts
@@ -93,7 +93,7 @@ export default class OAuthVerifier {
           key: `oauth:${oAuthToken}`,
           requiresVerification: false,
           userId,
-          verified: false,
+          verified: true,
         };
       }
     }

--- a/src/oauth-verifier.ts
+++ b/src/oauth-verifier.ts
@@ -93,7 +93,7 @@ export default class OAuthVerifier {
           key: `oauth:${oAuthToken}`,
           requiresVerification: false,
           userId,
-          verified: true,
+          verified: true, // this should match osu-web AuthApi
         };
       }
     }

--- a/src/oauth-verifier.ts
+++ b/src/oauth-verifier.ts
@@ -88,7 +88,7 @@ export default class OAuthVerifier {
     const scopes = JSON.parse(rows[0].scopes);
 
     for (const scope of scopes) {
-      if (scope === '*' || scope === 'read') {
+      if (scope === '*') {
         return {
           key: `oauth:${oAuthToken}`,
           requiresVerification: false,


### PR DESCRIPTION
This prevents requirement change from affecting token auth.

There's also an scope `read` check which isn't used anymore (I think?) and can be removed.