### PR TITLE
Update docker base image (and node version)

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           cache: 'yarn'
-          node-version: '12'
+          node-version: '18'
 
       - name: Install js dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           cache: 'yarn'
-          node-version: '12'
+          node-version: '18'
 
       - name: Install js dependencies
         run: yarn --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:18-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
That version 12 was like 3 years old. Also considered using lts tag (`lts-alpine`) but there's no test here yet so 🤷‍♀️

This should technically run on arm64 but I have no such machine so whoever has one should test it first.