### PR TITLE
Send ready message after connection boot completes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ const getUserSession = async (req: http.IncomingMessage) => {
 
 // variables
 const authenticationFailedMessage = JSON.stringify({ error: 'authentication failed' });
+const connectionReadyMessage = JSON.stringify({ event: 'connection.ready' });
 const db = mysql.createPool(config.db);
 const dogstatsd = new StatsD({ prefix: 'osu.notification.' });
 const redisSubscriber = new RedisSubscriber({ dogstatsd, redisConfig: config.redis.notification });
@@ -76,6 +77,7 @@ wss.on('connection', (ws: WebSocket, req: http.IncomingMessage) => {
     const connection = new UserConnection({ db, redisSubscriber, session, ws });
 
     connection.boot();
+    ws.send(connectionReadyMessage, noop);
   }).catch(() => {
     ws.send(authenticationFailedMessage, noop);
     ws.terminate();


### PR DESCRIPTION
Sends a message back to the client when the connection has finished setting up its event listeners.
I've noticed that it's possible for the browser to start sending the `chat.start` message from osu-web before the notification server even attaches the event listeners, causing the connection to not mark the `chatActive` state.